### PR TITLE
remove check for not ssr feature on dyn_classes that was blocking build with ssr feature enabled.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ cfg-if = "1.0.0"
 chrono = "0.4.31"
 
 [features]
-default = ["csr"]
+default = []
 csr = ["leptos/csr"]
 ssr = ["leptos/ssr", "leptos_meta/ssr"]
 hydrate = ["leptos/hydrate"]

--- a/src/alert/mod.rs
+++ b/src/alert/mod.rs
@@ -1,6 +1,6 @@
 mod theme;
 
-#[cfg(not(feature = "ssr"))]
+//#[cfg(not(feature = "ssr"))]
 use crate::utils::dyn_classes;
 use crate::{
     theme::use_theme,

--- a/src/avatar/mod.rs
+++ b/src/avatar/mod.rs
@@ -1,6 +1,6 @@
 mod theme;
 
-#[cfg(not(feature = "ssr"))]
+//#[cfg(not(feature = "ssr"))]
 use crate::utils::dyn_classes;
 use crate::{
     use_theme,

--- a/src/button/mod.rs
+++ b/src/button/mod.rs
@@ -1,7 +1,7 @@
 mod button_group;
 mod theme;
 
-#[cfg(not(feature = "ssr"))]
+//#[cfg(not(feature = "ssr"))]
 use crate::utils::dyn_classes;
 use crate::{
     components::{OptionComp, Wave, WaveRef},

--- a/src/spinner/mod.rs
+++ b/src/spinner/mod.rs
@@ -1,6 +1,6 @@
 mod theme;
 
-#[cfg(not(feature = "ssr"))]
+//#[cfg(not(feature = "ssr"))]
 use crate::utils::dyn_classes;
 use crate::{
     theme::use_theme,


### PR DESCRIPTION
removed ```
#[cfg(not(feature = "ssr"))]``` from a number of files.

dyn_classes seems to already check for ssr feature, and this was preventing building.

I also removed the csr default feature, as having both csr and ssr or hydrate enabled was breaking things.
