### PR TITLE
feat: Add min/max props into InputNumber

### DIFF
--- a/demo_markdown/docs/input_number/mod.md
+++ b/demo_markdown/docs/input_number/mod.md
@@ -12,6 +12,16 @@ view! {
 }
 ```
 
+### Min / Max
+
+```rust demo
+let value = create_rw_signal(0);
+
+view! {
+    <InputNumber value step=1 min=-1 max=2/>
+}
+```
+
 ### Disabled
 
 ```rust demo
@@ -32,16 +42,6 @@ view! {
 }
 ```
 
-### Min / Max
-
-```rust demo
-let value = create_rw_signal(0);
-
-view! {
-    <InputNumber value step=1 min=-1 max=2/>
-}
-```
-
 ### InputNumber Props
 
 | Name | Type | Default | Description |
@@ -50,15 +50,15 @@ view! {
 | value | `Model<T>` | `T::default()` | Set the input value. |
 | placeholder | `OptionalProp<MaybeSignal<String>>` | `Default::default()` | Placeholder of input number. |
 | step | `MaybeSignal<T>` |  | The number which the current value is increased or decreased on key or button press. |
+| min | `MaybeSignal<T>` | `T::min_value()` | The minimum number that the input value can take. |
+| max | `MaybeSignal<T>` | `T::max_value()` | The maximum number that the input value can take. |
 | disabled | `MaybeSignal<bool>` | `false` | Whether the input is disabled. |
 | invalid | `MaybeSignal<bool>` | `false` | Whether the input is invalid. |
 | attr: | `Vec<(&'static str, Attribute)>` | `Default::default()` | The dom attrs of the input element inside the component. |
-| min | `MaybeSignal<T>` | `T::min_value()` | The minimum number that the input value can take. |
-| max | `MaybeSignal<T>` | `T::max_value()` | The max number that the input value can take. |
 
 #### T impl
 
-`T: Add<Output = T> + Sub<Output = T> + PartialOrd + num_traits::Bounded + Default + Clone + FromStr + ToString + 'static`
+`T: Add<Output = T> + Sub<Output = T> + PartialOrd + num::Bounded + Default + Clone + FromStr + ToString + 'static`
 
 ### InputNumber Ref
 

--- a/demo_markdown/docs/input_number/mod.md
+++ b/demo_markdown/docs/input_number/mod.md
@@ -32,6 +32,16 @@ view! {
 }
 ```
 
+### Min / Max
+
+```rust demo
+let value = create_rw_signal(0);
+
+view! {
+    <InputNumber value step=1 min=-1 max=2/>
+}
+```
+
 ### InputNumber Props
 
 | Name | Type | Default | Description |
@@ -43,10 +53,12 @@ view! {
 | disabled | `MaybeSignal<bool>` | `false` | Whether the input is disabled. |
 | invalid | `MaybeSignal<bool>` | `false` | Whether the input is invalid. |
 | attr: | `Vec<(&'static str, Attribute)>` | `Default::default()` | The dom attrs of the input element inside the component. |
+| min | `MaybeSignal<T>` | `T::min_value()` | The minimum number that the input value can take. |
+| max | `MaybeSignal<T>` | `T::max_value()` | The max number that the input value can take. |
 
 #### T impl
 
-`T: Add<Output = T> + Sub<Output = T> + Default + Clone + FromStr + ToString + 'static`
+`T: Add<Output = T> + Sub<Output = T> + PartialOrd + num_traits::Bounded + Default + Clone + FromStr + ToString + 'static`
 
 ### InputNumber Ref
 

--- a/thaw/Cargo.toml
+++ b/thaw/Cargo.toml
@@ -29,6 +29,7 @@ uuid = { version = "1.7.0", features = ["v4"] }
 cfg-if = "1.0.0"
 chrono = "0.4.35"
 palette = "0.7.5"
+num-traits = "0.2.18"
 
 [features]
 csr = ["leptos/csr", "thaw_components/csr", "thaw_utils/csr"]

--- a/thaw/src/input_number/mod.rs
+++ b/thaw/src/input_number/mod.rs
@@ -1,6 +1,6 @@
 use crate::{Button, ButtonVariant, ComponentRef, Icon, Input, InputRef, InputSuffix};
 use leptos::*;
-use num_traits::bounds::Bounded;
+use num_traits::Bounded;
 use std::ops::{Add, Sub};
 use std::str::FromStr;
 use thaw_utils::{Model, OptionalProp, StoredMaybeSignal};
@@ -60,20 +60,22 @@ where
     });
 
     let set_within_range = Callback::<ev::FocusEvent>::new(move |_| {
-        let value_gotten = value.get_untracked();
+        let old_value = value.get_untracked();
         let min = min.get_untracked();
         let max = max.get_untracked();
-        if value_gotten < min {
-            value.set(min.clone());
-        } else if value_gotten > max {
-            value.set(max.clone());
+        if old_value < min {
+            value.set(min);
+        } else if old_value > max {
+            value.set(max);
         }
     });
 
     let minus_disabled = create_memo(move |_| disabled.get() || value.get() <= min.get());
     let plus_disabled = create_memo(move |_| disabled.get() || value.get() >= max.get());
-    let invalid =
-        create_memo(move |_| invalid.get() || value.get() < min.get() || value.get() > max.get());
+    let invalid = create_memo(move |_| {
+        let value = value.get();
+        invalid.get() || value < min.get() || value > max.get()
+    });
 
     view! {
         <Input

--- a/thaw/src/input_number/mod.rs
+++ b/thaw/src/input_number/mod.rs
@@ -1,5 +1,6 @@
 use crate::{Button, ButtonVariant, ComponentRef, Icon, Input, InputRef, InputSuffix};
 use leptos::*;
+use num_traits::bounds::Bounded;
 use std::ops::{Add, Sub};
 use std::str::FromStr;
 use thaw_utils::{Model, OptionalProp, StoredMaybeSignal};
@@ -14,9 +15,11 @@ pub fn InputNumber<T>(
     #[prop(optional, into)] class: OptionalProp<MaybeSignal<String>>,
     #[prop(optional)] comp_ref: ComponentRef<InputNumberRef>,
     #[prop(attrs)] attrs: Vec<(&'static str, Attribute)>,
+    #[prop(default = MaybeSignal::Static(T::min_value()), into)] min: MaybeSignal<T>,
+    #[prop(default = MaybeSignal::Static(T::max_value()), into)] max: MaybeSignal<T>,
 ) -> impl IntoView
 where
-    T: Add<Output = T> + Sub<Output = T>,
+    T: Add<Output = T> + Sub<Output = T> + PartialOrd + Bounded,
     T: Default + Clone + FromStr + ToString + 'static,
 {
     let input_value = create_rw_signal(String::default());
@@ -39,6 +42,8 @@ where
         true
     });
     let step: StoredMaybeSignal<_> = step.into();
+    let min: StoredMaybeSignal<_> = min.into();
+    let max: StoredMaybeSignal<_> = max.into();
 
     let add = Callback::<ev::MouseEvent>::new(move |e: ev::MouseEvent| {
         e.prevent_default();
@@ -54,6 +59,22 @@ where
         comp_ref.load(InputNumberRef { input_ref });
     });
 
+    let set_within_range = Callback::<ev::FocusEvent>::new(move |_| {
+        let value_gotten = value.get_untracked();
+        let min = min.get_untracked();
+        let max = max.get_untracked();
+        if value_gotten < min {
+            value.set(min.clone());
+        } else if value_gotten > max {
+            value.set(max.clone());
+        }
+    });
+
+    let minus_disabled = create_memo(move |_| disabled.get() || value.get() <= min.get());
+    let plus_disabled = create_memo(move |_| disabled.get() || value.get() >= max.get());
+    let invalid =
+        create_memo(move |_| invalid.get() || value.get() < min.get() || value.get() > max.get());
+
     view! {
         <Input
             attrs
@@ -64,12 +85,13 @@ where
             disabled
             invalid
             comp_ref=input_ref
+            on_blur=set_within_range
         >
             <InputSuffix slot>
-                <Button disabled variant=ButtonVariant::Link on_click=sub>
+                <Button disabled=minus_disabled variant=ButtonVariant::Link on_click=sub>
                     <Icon icon=icondata_ai::AiMinusOutlined style="font-size: 18px"/>
                 </Button>
-                <Button disabled variant=ButtonVariant::Link on_click=add>
+                <Button disabled=plus_disabled variant=ButtonVariant::Link on_click=add>
                     <Icon icon=icondata_ai::AiPlusOutlined style="font-size: 18px"/>
                 </Button>
             </InputSuffix>


### PR DESCRIPTION
Hello @luoxiaozero 

Added range with min/max props to InputNumber component.

When the input value reaches the limit, the plus/minus icon will be disabled.
If it goes out of range, the component will be invalid and will automatically fall within the range on blur.