### PR TITLE
Impl from `Signal` and `WriteSignal` for `Model`

### DIFF
--- a/thaw_utils/src/signals/model.rs
+++ b/thaw_utils/src/signals/model.rs
@@ -132,6 +132,16 @@ impl<T> From<RwSignal<T>> for Model<T> {
     }
 }
 
+impl<T> From<(Signal<T>, WriteSignal<T>)> for Model<T> {
+    fn from((read, write): (Signal<T>, WriteSignal<T>)) -> Self {
+        Self {
+            read,
+            write,
+            on_write: None,
+        }
+    }
+}
+
 impl<T> From<(ReadSignal<T>, WriteSignal<T>)> for Model<T> {
     fn from((read, write): (ReadSignal<T>, WriteSignal<T>)) -> Self {
         Self {


### PR DESCRIPTION
Previously there was no way to create a `Model` from a `Signal` and `WriteSignal`, despite those being the internal types used within the `Model`. This PR adds this implementation.