### PR TITLE
Remove fixed width on version switcher

### DIFF
--- a/demo/src/components/site_header.rs
+++ b/demo/src/components/site_header.rs
@@ -103,9 +103,6 @@ pub fn SiteHeader() -> impl IntoView {
                 .demo-header__menu-popover-mobile {
                     padding: 0;
                 }
-                .demo-header__right-btn .thaw-select {
-                    width: 60px;
-                }
                 @media screen and (max-width: 600px) {
                     .demo-header {
                         padding: 0 8px;


### PR DESCRIPTION
The branch switcher dropdown should probably not have a fixed width.

![image](https://github.com/thaw-ui/thaw/assets/1179415/50f502ea-9060-4adc-901e-f9c1234a03c6)
