### PR TITLE
Use fully qualified syntax in the example of `Drawer`

### DIFF
--- a/demo/src/pages/nav_bar/mod.rs
+++ b/demo/src/pages/nav_bar/mod.rs
@@ -4,7 +4,6 @@ use leptos::*;
 use thaw::mobile::{NavBar, NavBarRight};
 use thaw::Icon;
 
-
 #[component]
 pub fn NavBarPage() -> impl IntoView {
     view! {

--- a/demo_markdown/docs/drawer/mod.md
+++ b/demo_markdown/docs/drawer/mod.md
@@ -13,10 +13,10 @@ let open = Callback::new(move |new_placement: DrawerPlacement| {
 
 view! {
     <ButtonGroup>
-        <Button on_click=Callback::new(move |_| open.call(DrawerPlacement::Top))>"Top"</Button>
-        <Button on_click=Callback::new(move |_| open.call(DrawerPlacement::Right))>"Right"</Button>
-        <Button on_click=Callback::new(move |_| open.call(DrawerPlacement::Bottom))>"Bottom"</Button>
-        <Button on_click=Callback::new(move |_| open.call(DrawerPlacement::Left))>"Left"</Button>
+        <Button on_click=Callback::new(move |_| leptos::Callable::call(&open, DrawerPlacement::Top))>"Top"</Button>
+        <Button on_click=Callback::new(move |_| leptos::Callable::call(&open, DrawerPlacement::Right))>"Right"</Button>
+        <Button on_click=Callback::new(move |_| leptos::Callable::call(&open, DrawerPlacement::Bottom))>"Bottom"</Button>
+        <Button on_click=Callback::new(move |_| leptos::Callable::call(&open, DrawerPlacement::Left))>"Left"</Button>
     </ButtonGroup>
     <Drawer title="Title" show placement>
         "Hello"

--- a/demo_markdown/src/lib.rs
+++ b/demo_markdown/src/lib.rs
@@ -96,7 +96,7 @@ pub fn include_md(_token_stream: proc_macro::TokenStream) -> proc_macro::TokenSt
                 links
             );
             syn::parse_str::<ItemFn>(&toc)
-                .expect(&format!("Cannot be resolved as a function: \n {toc}"))
+                .unwrap_or_else(|_| panic!("Cannot be resolved as a function: \n {toc}"))
         };
 
         let demos: Vec<ItemFn> = demos

--- a/demo_markdown/src/markdown/code_block.rs
+++ b/demo_markdown/src/markdown/code_block.rs
@@ -55,9 +55,7 @@ static SYNTAX_SET: OnceLock<SyntaxSet> = OnceLock::new();
 
 fn highlight_to_html(text: &str, syntax: &str) -> Option<String> {
     let syntax_set = SYNTAX_SET.get_or_init(|| SyntaxSet::load_defaults_newlines());
-    let Some(syntax) = syntax_set.find_syntax_by_token(syntax) else {
-        return None;
-    };
+    let syntax = syntax_set.find_syntax_by_token(syntax)?;
 
     let mut html_generator = ClassedHTMLGenerator::new_with_class_style(
         syntax,

--- a/demo_markdown/src/markdown/code_block.rs
+++ b/demo_markdown/src/markdown/code_block.rs
@@ -18,8 +18,7 @@ pub fn to_tokens(code_block: &NodeCodeBlock, demos: &mut Vec<String>) -> TokenSt
         let literal = langs
             .iter()
             .find(|lang| lang != &&"demo")
-            .map(|lang| highlight_to_html(&code_block.literal, lang))
-            .flatten()
+            .and_then(|lang| highlight_to_html(&code_block.literal, lang))
             .unwrap_or_else(|| {
                 is_highlight = false;
                 code_block.literal.clone()
@@ -37,8 +36,7 @@ pub fn to_tokens(code_block: &NodeCodeBlock, demos: &mut Vec<String>) -> TokenSt
         let mut is_highlight = true;
         let literal = langs
             .first()
-            .map(|lang| highlight_to_html(&code_block.literal, lang))
-            .flatten()
+            .and_then(|lang| highlight_to_html(&code_block.literal, lang))
             .unwrap_or_else(|| {
                 is_highlight = false;
                 code_block.literal.clone()

--- a/demo_markdown/src/markdown/code_block.rs
+++ b/demo_markdown/src/markdown/code_block.rs
@@ -54,7 +54,7 @@ pub fn to_tokens(code_block: &NodeCodeBlock, demos: &mut Vec<String>) -> TokenSt
 static SYNTAX_SET: OnceLock<SyntaxSet> = OnceLock::new();
 
 fn highlight_to_html(text: &str, syntax: &str) -> Option<String> {
-    let syntax_set = SYNTAX_SET.get_or_init(|| SyntaxSet::load_defaults_newlines());
+    let syntax_set = SYNTAX_SET.get_or_init(SyntaxSet::load_defaults_newlines);
     let syntax = syntax_set.find_syntax_by_token(syntax)?;
 
     let mut html_generator = ClassedHTMLGenerator::new_with_class_style(

--- a/demo_markdown/src/markdown/mod.rs
+++ b/demo_markdown/src/markdown/mod.rs
@@ -62,7 +62,7 @@ fn iter_nodes<'a>(
         ),
         NodeValue::Heading(node_h) => {
             let sourcepos = node.data.borrow().sourcepos;
-            let text = range_text(md_text, sourcepos.start.clone(), sourcepos.end.clone());
+            let text = range_text(md_text, sourcepos.start, sourcepos.end);
             let level = node_h.level as usize + 1;
             let text = text[level..].to_string();
             let h_id = format!("{}", text.replace(' ', "-").to_ascii_lowercase());

--- a/demo_markdown/src/markdown/mod.rs
+++ b/demo_markdown/src/markdown/mod.rs
@@ -18,7 +18,7 @@ pub fn parse_markdown(
     let mut options = comrak::Options::default();
     options.extension.table = true;
 
-    let root = parse_document(&arena, &md_text, &options);
+    let root = parse_document(&arena, md_text, &options);
     let body = iter_nodes(md_text, root, &mut demos, &mut toc);
     Ok((body, demos, toc))
 }
@@ -186,7 +186,7 @@ fn range_text(text: &str, start: LineColumn, end: LineColumn) -> &str {
     let mut current_line_num = start_line + 1;
     while current_line_num < end_line {
         let next_line = lines.next().unwrap_or("");
-        start_line_text = &next_line;
+        start_line_text = next_line;
         current_line_num += 1;
     }
 

--- a/demo_markdown/src/markdown/mod.rs
+++ b/demo_markdown/src/markdown/mod.rs
@@ -48,8 +48,12 @@ fn iter_nodes<'a>(
         NodeValue::HtmlBlock(node_html_block) => {
             let html =
                 syn::parse_str::<ItemMacro>(&format!("view! {{ {} }}", node_html_block.literal))
-                    .unwrap_or_else(|_| panic!("Cannot be resolved as a macro: \n {}",
-                        node_html_block.literal));
+                    .unwrap_or_else(|_| {
+                        panic!(
+                            "Cannot be resolved as a macro: \n {}",
+                            node_html_block.literal
+                        )
+                    });
             quote!(
                 {
                     #html

--- a/demo_markdown/src/markdown/mod.rs
+++ b/demo_markdown/src/markdown/mod.rs
@@ -8,6 +8,7 @@ use proc_macro2::{Ident, Span, TokenStream};
 use quote::quote;
 use syn::ItemMacro;
 
+#[allow(clippy::type_complexity)]
 pub fn parse_markdown(
     md_text: &str,
 ) -> Result<(TokenStream, Vec<String>, Vec<(String, String)>), String> {
@@ -65,7 +66,7 @@ fn iter_nodes<'a>(
             let text = range_text(md_text, sourcepos.start, sourcepos.end);
             let level = node_h.level as usize + 1;
             let text = text[level..].to_string();
-            let h_id = format!("{}", text.replace(' ', "-").to_ascii_lowercase());
+            let h_id = text.replace(' ', "-").to_ascii_lowercase().to_string();
             toc.push((h_id.clone(), text));
             let h = Ident::new(&format!("h{}", node_h.level), Span::call_site());
             quote!(

--- a/demo_markdown/src/markdown/mod.rs
+++ b/demo_markdown/src/markdown/mod.rs
@@ -8,7 +8,9 @@ use proc_macro2::{Ident, Span, TokenStream};
 use quote::quote;
 use syn::ItemMacro;
 
-pub fn parse_markdown(md_text: &str) -> Result<(TokenStream, Vec<String>, Vec<(String, String)>), String> {
+pub fn parse_markdown(
+    md_text: &str,
+) -> Result<(TokenStream, Vec<String>, Vec<(String, String)>), String> {
     let mut demos: Vec<String> = vec![];
     let mut toc: Vec<(String, String)> = vec![];
 
@@ -45,10 +47,8 @@ fn iter_nodes<'a>(
         NodeValue::HtmlBlock(node_html_block) => {
             let html =
                 syn::parse_str::<ItemMacro>(&format!("view! {{ {} }}", node_html_block.literal))
-                    .expect(&format!(
-                        "Cannot be resolved as a macro: \n {}",
-                        node_html_block.literal
-                    ));
+                    .unwrap_or_else(|_| panic!("Cannot be resolved as a macro: \n {}",
+                        node_html_block.literal));
             quote!(
                 {
                     #html

--- a/thaw/src/back_top/mod.rs
+++ b/thaw/src/back_top/mod.rs
@@ -6,7 +6,8 @@ use crate::{use_theme, Icon, Theme};
 use leptos::{html::ToHtmlElement, *};
 use thaw_components::{CSSTransition, Fallback, OptionComp, Teleport};
 use thaw_utils::{
-    add_event_listener, class_list, get_scroll_parent, mount_style, EventListenerHandle, OptionalProp,
+    add_event_listener, class_list, get_scroll_parent, mount_style, EventListenerHandle,
+    OptionalProp,
 };
 
 #[component]

--- a/thaw/src/back_top/theme.rs
+++ b/thaw/src/back_top/theme.rs
@@ -3,7 +3,6 @@ use crate::theme::ThemeMethod;
 #[derive(Clone)]
 pub struct BackTopTheme {
     pub background_color: String,
-    
 }
 
 impl ThemeMethod for BackTopTheme {

--- a/thaw_utils/src/class_list.rs
+++ b/thaw_utils/src/class_list.rs
@@ -5,6 +5,12 @@ use std::{collections::HashSet, rc::Rc};
 
 pub struct ClassList(RwSignal<HashSet<Oco<'static, str>>>);
 
+impl Default for ClassList {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl ClassList {
     pub fn new() -> Self {
         Self(RwSignal::new(HashSet::new()))

--- a/thaw_utils/src/dom/get_scroll_parent.rs
+++ b/thaw_utils/src/dom/get_scroll_parent.rs
@@ -4,9 +4,7 @@ use leptos::{
 };
 
 pub fn get_scroll_parent(element: &HtmlElement<AnyElement>) -> Option<HtmlElement<AnyElement>> {
-    let Some(parent_element) = get_parent_element(element) else {
-        return None;
-    };
+    let parent_element = get_parent_element(element)?;
 
     if parent_element.node_type() == 9 {
         return Some(parent_element);

--- a/thaw_utils/src/hooks/use_click_position.rs
+++ b/thaw_utils/src/hooks/use_click_position.rs
@@ -12,9 +12,7 @@ pub fn use_click_position() -> ReadSignal<Option<(i32, i32)>> {
             if event.client_x() > 0 || event.client_y() > 0 {
                 return Some((event.client_x(), event.client_y()));
             }
-            let Some(target) = event.target() else {
-                return None;
-            };
+            let target = event.target()?;
 
             let Ok(target) = target.dyn_into::<web_sys::Element>() else {
                 return None;

--- a/thaw_utils/src/hooks/use_lock_html_scroll.rs
+++ b/thaw_utils/src/hooks/use_lock_html_scroll.rs
@@ -20,7 +20,7 @@ pub fn use_lock_html_scroll(is_lock: MaybeSignal<bool>) {
                 let style = document()
                     .create_element("style")
                     .expect("create style element error");
-                _ = style.set_attribute("data-id", &format!("thaw-lock-html-scroll"));
+                _ = style.set_attribute("data-id", "thaw-lock-html-scroll");
                 style.set_text_content(Some("html { overflow: hidden; }"));
                 _ = head.append_child(&style);
                 style_el.set_value(Some(style));

--- a/thaw_utils/src/hooks/use_next_frame.rs
+++ b/thaw_utils/src/hooks/use_next_frame.rs
@@ -22,7 +22,7 @@ impl NextFrame {
     pub fn run(&self, cb: impl FnOnce() + 'static) {
         self.cancel();
 
-        let next_frame_hadnle = self.0.clone();
+        let next_frame_hadnle = self.0;
         let handle = request_animation_frame_with_handle(move || {
             let handle = request_animation_frame_with_handle(cb).unwrap();
             next_frame_hadnle.set_value(Some(handle));

--- a/thaw_utils/src/throttle.rs
+++ b/thaw_utils/src/throttle.rs
@@ -1,7 +1,7 @@
 use leptos::{leptos_dom::helpers::TimeoutHandle, *};
 use std::time::Duration;
 
-pub fn throttle(cb: impl Fn() + 'static, duration: Duration) -> impl Fn() -> () {
+pub fn throttle(cb: impl Fn() + 'static, duration: Duration) -> impl Fn() {
     let cb = Callback::new(move |_| cb());
     let timeout_handle = StoredValue::new(None::<TimeoutHandle>);
     on_cleanup(move || {


### PR DESCRIPTION
According to https://github.com/rust-lang/rust/issues/48919, a method with this name may be added to the standard library in the future, which may cause ambiguity or even change the behavior. So it would be better to use fully qualified syntax here:

```diff
-<Button on_click=Callback::new(move |_| open.call(DrawerPlacement::Top))>"Top"</Button>
+<Button on_click=Callback::new(move |_| leptos::Callable::call(&open, DrawerPlacement::Top))>"Top"</Button>
```

Also, some clippy lints also have been fixed separately 🍔 