### PR TITLE
fix(Message): interchange the icons of `MessageVariant::Success` and `MessageVariant::Error`

### DIFF
--- a/thaw/src/message/mod.rs
+++ b/thaw/src/message/mod.rs
@@ -20,9 +20,9 @@ pub enum MessageVariant {
 impl MessageVariant {
     fn icon(&self) -> icondata_core::Icon {
         match self {
-            MessageVariant::Success => icondata_ai::AiCloseCircleFilled,
+            MessageVariant::Success => icondata_ai::AiCheckCircleFilled,
             MessageVariant::Warning => icondata_ai::AiExclamationCircleFilled,
-            MessageVariant::Error => icondata_ai::AiCheckCircleFilled,
+            MessageVariant::Error => icondata_ai::AiCloseCircleFilled,
         }
     }
     fn theme_color(&self, theme: &Theme) -> String {


### PR DESCRIPTION
It should be the ✓ for success and the ✗ for error to make more intuitive sense.

## Before

![image](https://github.com/thaw-ui/thaw/assets/17194719/7f85bff5-ae37-427b-8bfb-843fd668f37e)

## After

![image](https://github.com/thaw-ui/thaw/assets/17194719/b9b0433a-79c5-4dca-8945-e6b09c251884)
