### PR TITLE
Adding implemenatation of From trait to Model for derived signals

### DIFF
--- a/thaw_utils/src/signals/model.rs
+++ b/thaw_utils/src/signals/model.rs
@@ -162,7 +162,7 @@ impl<T> From<(Memo<T>, WriteSignal<T>)> for Model<T> {
     }
 }
 
-impl<T: Clone + Default> From<Signal<T>> for Model<T> {
+impl<T: Clone> From<Signal<T>> for Model<T> {
     fn from(read: Signal<T>) -> Self {
         let mut model = Self::new(read.get());
         model.on_write = None;

--- a/thaw_utils/src/signals/model.rs
+++ b/thaw_utils/src/signals/model.rs
@@ -162,6 +162,14 @@ impl<T> From<(Memo<T>, WriteSignal<T>)> for Model<T> {
     }
 }
 
+impl<T: Clone + Default> From<Signal<T>> for Model<T> {
+    fn from(read: Signal<T>) -> Self {
+        let mut model = Self::new(read.get());
+        model.on_write = None;
+        model
+    }
+}
+
 impl<T: Default> From<(Option<T>, WriteSignal<T>)> for Model<T> {
     fn from((read, write): (Option<T>, WriteSignal<T>)) -> Self {
         let mut model = Self::new(read.unwrap_or_default());
@@ -197,6 +205,11 @@ mod test {
         let model: Model<i32> = (read, write).into();
         assert_eq!(model.get_untracked(), 0);
         model.set(1);
+        assert_eq!(model.get_untracked(), 1);
+
+        // Derived
+        let derived = Signal::derive(move || rw_signal.get()); 
+        let model: Model<i32> = derived.into();
         assert_eq!(model.get_untracked(), 1);
 
         runtime.dispose();


### PR DESCRIPTION
Hi,

I'm trying to do something like that:

```
let error : RwSignal<Option<SomeError>> = create_rw_signal(None);
let show_error = Signal::derive(move||error.get().is_some()); 

<Modal title="title" show=show_error>
   { display error}
</Modal> 
```

This didn't work because `show` has type Model<bool> and you can't create Model from derived signal.

I've added the `From<Signal<T>> for Model<T>` implementation and it's working now.

Is this a good approach? I think especially for components like Modal handling derived signal is very useful but maybe there's better way to do it. 