### PR TITLE
fix scrollbar panic

### DIFF
--- a/thaw/src/scrollbar/mod.rs
+++ b/thaw/src/scrollbar/mod.rs
@@ -157,7 +157,7 @@ pub fn Scrollbar(
         sync_scroll_state();
     };
     let on_mouseleave = move |_| {
-        thumb_status.update_value(|thumb_status| {
+        thumb_status.try_update_value(|thumb_status| {
             if thumb_status.is_some() {
                 *thumb_status = Some(ThumbStatus::DelayLeave);
             } else {


### PR DESCRIPTION
Hi,

I'm getting following errors from the scrollbar component:

```
repo/thaw/thaw/src/scrollbar/mod.rs:160:22:
could not set stored value

Stack:

@http://localhost:1420/twili-recipes-ui-185fc906b025bcf7.js:507:26
twili_recipes_ui-6eb6c11dcaa98b55.wasm.wasm-function[console_error_panic_hook::Error::new::he0c5f77003cc61aa]@[wasm code]
twili_recipes_ui-6eb6c11dcaa98b55.wasm.wasm-function[console_error_panic_hook::hook_impl::h6a0063ad36e0b326]@[wasm code]
twili_recipes_ui-6eb6c11dcaa98b55.wasm.wasm-function[console_error_panic_hook::hook::hfdf1575546c7f72c]@[wasm code]
twili_recipes_ui-6eb6c11dcaa98b55.wasm.wasm-function[core::ops::function::Fn::call::h886484cdfff24eff]@[wasm code]
twili_recipes_ui-6eb6c11dcaa98b55.wasm.wasm-function[std::panicking::rust_panic_with_hook::h3fe0a99cc3d59b9d]@[wasm code]
twili_recipes_ui-6eb6c11dcaa98b55.wasm.wasm-function[std::panicking::begin_panic_handler::{{closure}}::hedb4ab624dc824be]@[wasm code]
twili_recipes_ui-6eb6c11dcaa98b55.wasm.wasm-function[std::sys_common::backtrace::__rust_end_short_backtrace::h8cb0815ee02b0c4b]@[wasm code]
twili_recipes_ui-6eb6c11dcaa98b55.wasm.wasm-function[rust_begin_unwind]@[wasm code]
twili_recipes_ui-6eb6c11dcaa98b55.wasm.wasm-function[core::panicking::panic_fmt::hed419a1f036a3f05]@[wasm code]
twili_recipes_ui-6eb6c11dcaa98b55.wasm.wasm-function[core::panicking::panic_display::hb1cf8e721485f805]@[wasm code]
twili_recipes_ui-6eb6c11dcaa98b55.wasm.wasm-function[core::option::expect_failed::h9d2ed5cc15c4fbce]@[wasm code]
twili_recipes_ui-6eb6c11dcaa98b55.wasm.wasm-function[core::option::Option<T>::expect::hcc09897e3e07d106]@[wasm code]
twili_recipes_ui-6eb6c11dcaa98b55.wasm.wasm-function[leptos_reactive::stored_value::StoredValue<T>::update_value::ha7197f3a8e421e06]@[wasm code]
twili_recipes_ui-6eb6c11dcaa98b55.wasm.wasm-function[thaw::scrollbar::__Scrollbar::{{closure}}::h04085dcd482e18a3]@[wasm code]
twili_recipes_ui-6eb6c11dcaa98b55.wasm.wasm-function[<alloc::boxed::Box<F,A> as core::ops::function::FnMut<Args>>::call_mut::hb22e1555ee881bd1]@[wasm code]
twili_recipes_ui-6eb6c11dcaa98b55.wasm.wasm-function[leptos_dom::events::add_event_listener_undelegated::{{closure}}::ha2ec7cec74454f19]@[wasm code]
twili_recipes_ui-6eb6c11dcaa98b55.wasm.wasm-function[<dyn core::ops::function::FnMut<(A,)>+Output = R as wasm_bindgen::closure::WasmClosure>::describe::invoke::hf38edaffd835d150]@[wasm code]
__wbg_adapter_61@http://localhost:1420/twili-recipes-ui-185fc906b025bcf7.js:244:134
real@http://localhost:1420/twili-recipes-ui-185fc906b025bcf7.js:209:21
```

I think this is because the `on_mouseleave` fires only when the mouse is moved. So for example if I click on a button to navigate to another page and the element with scrollbar is removed the event doesn't fire immediately. If fires when I move the mouse but since the scrollbar is long gone the `update_value` call fails. Changing this to 'try_update_value' fixes the errors in the console. I think the error is the only issue here, the application functions normally.  