### PR TITLE
add class to modal

### DIFF
--- a/demo_markdown/docs/modal/mod.md
+++ b/demo_markdown/docs/modal/mod.md
@@ -15,6 +15,7 @@ view! {
 
 | Name           | Type                  | Default              | Description                                 |
 | -------------- | --------------------- | -------------------- | ------------------------------------------- |
+| class          | `OptionalProp<MaybeSignal<String>>` | `Default::default()` | Addtional classes for the modal element. |
 | show           | `Model<bool>`         |                      | Whether to show modal.                      |
 | title          | `MaybeSignal<String>` | `Default::default()` | Modal title.                                |
 | width          | `MaybeSignal<String>` | `600px`              | Modal width.                                |

--- a/demo_markdown/docs/modal/mod.md
+++ b/demo_markdown/docs/modal/mod.md
@@ -22,6 +22,7 @@ view! {
 | z_index        | `MaybeSignal<i16>`    | `2000`               | z-index of the modal.                       |
 | mask_closeable | `MaybeSignal<bool>`   | `true`               | Whether to emit hide event when click mask. |
 | close_on_esc   | `bool`                | `true`               | Whether to close modal on Esc is pressed.   |
+| closable       | `bool`                | `true`               | Whether to display the close button.        |
 | children       | `Children`            |                      | Modal's content.                            |
 
 ### Modal Slots

--- a/thaw/src/modal/mod.rs
+++ b/thaw/src/modal/mod.rs
@@ -141,5 +141,3 @@ pub fn Modal(
         </Teleport>
     }
 }
-
-

--- a/thaw/src/modal/mod.rs
+++ b/thaw/src/modal/mod.rs
@@ -1,6 +1,6 @@
 use crate::{Card, CardFooter, CardHeader, CardHeaderExtra, Icon, Scrollbar, ScrollbarRef};
 use leptos::*;
-use thaw_components::{CSSTransition, FocusTrap, OptionComp, Teleport};
+use thaw_components::{CSSTransition, FocusTrap, If, OptionComp, Teleport, Then};
 use thaw_utils::{class_list, mount_style, use_click_position, ComponentRef, Model, OptionalProp};
 
 #[slot]
@@ -13,6 +13,7 @@ pub fn Modal(
     #[prop(into)] show: Model<bool>,
     #[prop(default = true.into(), into)] mask_closeable: MaybeSignal<bool>,
     #[prop(default = true, into)] close_on_esc: bool,
+    #[prop(default = true, into)] closable: bool,
     #[prop(default = 2000.into(), into)] z_index: MaybeSignal<i16>,
     #[prop(default = MaybeSignal::Static("600px".to_string()), into)] width: MaybeSignal<String>,
     #[prop(optional, into)] title: MaybeSignal<String>,
@@ -108,7 +109,9 @@ pub fn Modal(
                             let:display
                         >
                             <div
-                                class=class_list!["thaw-modal-body", class.map(| c | move || c.get())]
+                                class=class_list![
+                                    "thaw-modal-body", class.map(| c | move || c.get())
+                                ]
                                 ref=modal_ref
                                 role="dialog"
                                 aria-modal="true"
@@ -119,12 +122,16 @@ pub fn Modal(
                                         <span class="thaw-model-title">{move || title.get()}</span>
                                     </CardHeader>
                                     <CardHeaderExtra slot>
-                                        <span
-                                            style="cursor: pointer;"
-                                            on:click=move |_| show.set(false)
-                                        >
-                                            <Icon icon=icondata_ai::AiCloseOutlined/>
-                                        </span>
+                                        <If cond=closable>
+                                            <Then slot>
+                                                <span
+                                                    style="cursor: pointer;"
+                                                    on:click=move |_| show.set(false)
+                                                >
+                                                    <Icon icon=icondata_ai::AiCloseOutlined/>
+                                                </span>
+                                            </Then>
+                                        </If>
                                     </CardHeaderExtra>
                                     {children()}
                                     <CardFooter slot if_=modal_footer.is_some()>

--- a/thaw/src/modal/mod.rs
+++ b/thaw/src/modal/mod.rs
@@ -1,7 +1,7 @@
 use crate::{Card, CardFooter, CardHeader, CardHeaderExtra, Icon, Scrollbar, ScrollbarRef};
 use leptos::*;
 use thaw_components::{CSSTransition, FocusTrap, OptionComp, Teleport};
-use thaw_utils::{mount_style, use_click_position, ComponentRef, Model};
+use thaw_utils::{class_list, mount_style, use_click_position, ComponentRef, Model, OptionalProp};
 
 #[slot]
 pub struct ModalFooter {
@@ -18,6 +18,7 @@ pub fn Modal(
     #[prop(optional, into)] title: MaybeSignal<String>,
     children: Children,
     #[prop(optional)] modal_footer: Option<ModalFooter>,
+    #[prop(optional, into)] class: OptionalProp<MaybeSignal<String>>,
 ) -> impl IntoView {
     mount_style("modal", include_str!("./modal.css"));
 
@@ -80,6 +81,7 @@ pub fn Modal(
                                 String::from("display: none")
                             }
                         })
+
                         comp_ref=scrollbar_ref
                     >
                         <CSSTransition
@@ -106,7 +108,7 @@ pub fn Modal(
                             let:display
                         >
                             <div
-                                class="thaw-modal-body"
+                                class=class_list!["thaw-modal-body", class.map(| c | move || c.get())]
                                 ref=modal_ref
                                 role="dialog"
                                 aria-modal="true"
@@ -139,3 +141,5 @@ pub fn Modal(
         </Teleport>
     }
 }
+
+


### PR DESCRIPTION
Hi, added class to the modal component. Without it I couldn't make it responsive and fit nicely on mobile. 
I tested the component but I'm getting errors when I try to build the demo page:

```
error[E0282]: type annotations needed for `Box<_>`
  --> /opt/cargo/registry/src/index.crates.io-6f17d22bba15001f/time-0.3.30/src/format_description/parse/mod.rs:83:9
   |
83 |     let items = format_items
   |         ^^^^^
...
86 |     Ok(items.into())
   |              ---- type must be known at this point
   |
help: consider giving `items` an explicit type, where the placeholders `_` are specified
   |
83 |     let items: Box<_> = format_items
   |              ++++++++
```
Hope the markdown is ok. 
Any idea what is causing the error? I'm on rust 1.80.0-nightly. 

