### PR TITLE
Feat/input parser and formatter

### DIFF
--- a/demo_markdown/docs/input/mod.md
+++ b/demo_markdown/docs/input/mod.md
@@ -102,6 +102,25 @@ view! {
 }
 ```
 
+### Formatter
+
+```rust demo
+let value = create_rw_signal(String::from("loren_ipsun"));
+
+let formatter = Callback::<String, String>::new(move |v: String| {
+    v.replace("_", " ")
+});
+
+let parser = Callback::<String, String>::new(move |v: String| {
+    v.replace(" ", "_")
+});
+
+view! {
+    <Input value parser formatter />
+    <p>"Underlying value: "{ value }</p>
+}
+```
+
 ### Input Props
 
 | Name | Type | Default | Description |

--- a/demo_markdown/docs/input_number/mod.md
+++ b/demo_markdown/docs/input_number/mod.md
@@ -48,11 +48,8 @@ view! {
 let value = create_rw_signal(0.0);
 
 let formatter = Callback::<String, String>::new(move |v: String| {
-    let mut int: String = if v.chars().count() < 4 { 
-        String::from("0") 
-    } else {
-        v.chars().take(v.chars().count() - 3).collect() 
-    };
+    let dot_pos = v.chars().position(|c| c == '.').unwrap_or_else(|| v.chars().count());
+    let mut int: String = v.chars().take(dot_pos).collect();
 
     let sign: String = if v.chars().take(1).collect::<String>() == String::from("-") { 
         int = int.chars().skip(1).collect();
@@ -61,11 +58,7 @@ let formatter = Callback::<String, String>::new(move |v: String| {
         String::from("") 
     };
 
-    let dec: String = if v.chars().count() < 2 {
-        format!("{:0>2}" , v)
-    } else {
-        v.chars().skip(v.chars().count() - 2).take(2).collect()
-    };
+    let dec: String = v.chars().skip(dot_pos + 1).take(2).collect();
 
     let int = int
         .as_bytes()
@@ -74,19 +67,19 @@ let formatter = Callback::<String, String>::new(move |v: String| {
         .map(std::str::from_utf8)
         .collect::<Result<Vec<&str>, _>>()
         .unwrap()
-        .join("."); // separator
-    format!("{}{},{:0>2}", sign, int, dec)
+        .join(".");
+    format!("{}{},{:0<2}", sign, int, dec)
 });
 
 let parser = Callback::<String, String>::new(move |v: String| {
     let digits = v.chars().filter(|a| a.is_digit(10)).collect::<String>();
     let float = digits.parse::<f64>().unwrap_or_else(|_| 1.0);
-    format!("{:.2}", float / 100.0)
+    format!("{:.2}", float.round() / 100.0)
 });
 
 view! {
-    <InputNumber value parser formatter step=0.01 />
-    <p>{ value }</p>
+    <InputNumber value parser formatter step=1.0 />
+    <p>"Underlying value: "{ value }</p>
 }
 ```
 ### InputNumber Props

--- a/demo_markdown/docs/input_number/mod.md
+++ b/demo_markdown/docs/input_number/mod.md
@@ -42,6 +42,53 @@ view! {
 }
 ```
 
+### Formatter
+
+```rust demo
+let value = create_rw_signal(0.0);
+
+let formatter = Callback::<String, String>::new(move |v: String| {
+    let mut int: String = if v.chars().count() < 4 { 
+        String::from("0") 
+    } else {
+        v.chars().take(v.chars().count() - 3).collect() 
+    };
+
+    let sign: String = if v.chars().take(1).collect::<String>() == String::from("-") { 
+        int = int.chars().skip(1).collect();
+        String::from("-")
+    } else { 
+        String::from("") 
+    };
+
+    let dec: String = if v.chars().count() < 2 {
+        format!("{:0>2}" , v)
+    } else {
+        v.chars().skip(v.chars().count() - 2).take(2).collect()
+    };
+
+    let int = int
+        .as_bytes()
+        .rchunks(3)
+        .rev()
+        .map(std::str::from_utf8)
+        .collect::<Result<Vec<&str>, _>>()
+        .unwrap()
+        .join("."); // separator
+    format!("{}{},{:0>2}", sign, int, dec)
+});
+
+let parser = Callback::<String, String>::new(move |v: String| {
+    let digits = v.chars().filter(|a| a.is_digit(10)).collect::<String>();
+    let float = digits.parse::<f64>().unwrap_or_else(|_| 1.0);
+    format!("{:.2}", float / 100.0)
+});
+
+view! {
+    <InputNumber value parser formatter step=0.01 />
+    <p>{ value }</p>
+}
+```
 ### InputNumber Props
 
 | Name | Type | Default | Description |

--- a/demo_markdown/docs/menu/mod.md
+++ b/demo_markdown/docs/menu/mod.md
@@ -5,8 +5,12 @@ let value = create_rw_signal(String::from("o"));
 
 view! {
     <Menu value>
-        <MenuItem key="a" label="and"/>
-        <MenuItem key="o" label="or"/>
+        <MenuItem key="a" label="And"/>
+        <MenuItem key="o" label="Or"/>
+        <MenuItem icon=icondata::AiAreaChartOutlined key="area" label="Area Chart"/>
+        <MenuItem icon=icondata::AiPieChartOutlined key="pie" label="Pie Chart"/>
+        <MenuItem icon=icondata::AiGithubOutlined key="github" label="Github"/>
+        <MenuItem icon=icondata::AiChromeOutlined key="chrome" label="Chrome"/>
     </Menu>
 }
 ```
@@ -29,8 +33,9 @@ view! {
 
 ### MenuItem Props
 
-| Name  | Type                                | Default              | Description                                  |
-| ----- | ----------------------------------- | -------------------- | -------------------------------------------- |
+| Name | Type | Default | Description |
+| --- | --- | --- | --- |
 | class | `OptionalProp<MaybeSignal<String>>` | `Default::default()` | Addtional classes for the menu item element. |
-| label | `MaybeSignal<String>`               | `Default::default()` | The label of the menu item.                  |
-| key   | `MaybeSignal<String>`               | `Default::default()` | The indentifier of the menu item.            |
+| label | `MaybeSignal<String>` | `Default::default()` | The label of the menu item. |
+| key | `MaybeSignal<String>` | `Default::default()` | The indentifier of the menu item. |
+| icon | `OptionalMaybeSignal<icondata_core::Icon>` | `None` | The icon of the menu item. |

--- a/thaw/src/input_number/mod.rs
+++ b/thaw/src/input_number/mod.rs
@@ -33,6 +33,7 @@ where
                     return prev;
                 }
             }
+            input_value.set(value.clone());
             value
         })
     });

--- a/thaw/src/input_number/mod.rs
+++ b/thaw/src/input_number/mod.rs
@@ -14,6 +14,8 @@ pub fn InputNumber<T>(
     #[prop(optional, into)] invalid: MaybeSignal<bool>,
     #[prop(optional, into)] class: OptionalProp<MaybeSignal<String>>,
     #[prop(optional)] comp_ref: ComponentRef<InputNumberRef>,
+    #[prop(optional, into)] parser: OptionalProp<Callback<String, String>>,
+    #[prop(optional, into)] formatter: OptionalProp<Callback<String, String>>,
     #[prop(attrs)] attrs: Vec<(&'static str, Attribute)>,
     #[prop(default = MaybeSignal::Static(T::min_value()), into)] min: MaybeSignal<T>,
     #[prop(default = MaybeSignal::Static(T::max_value()), into)] max: MaybeSignal<T>,
@@ -31,7 +33,6 @@ where
                     return prev;
                 }
             }
-            input_value.set(value.clone());
             value
         })
     });
@@ -88,6 +89,8 @@ where
             invalid
             comp_ref=input_ref
             on_blur=set_within_range
+            parser
+            formatter
         >
             <InputSuffix slot>
                 <Button disabled=minus_disabled variant=ButtonVariant::Link on_click=sub>

--- a/thaw/src/menu/menu-item.css
+++ b/thaw/src/menu/menu-item.css
@@ -1,4 +1,6 @@
 .thaw-menu-item__content {
+    display: flex;
+    align-items: center;
     margin: 0.3rem 0.4rem;
     padding: 0.5rem 0.75rem;
     color: var(--thaw-font-color);

--- a/thaw/src/menu/menu_item.rs
+++ b/thaw/src/menu/menu_item.rs
@@ -1,11 +1,13 @@
 use super::use_menu;
-use crate::{theme::use_theme, Theme};
+use crate::{theme::use_theme, Icon, Theme};
 use leptos::*;
-use thaw_utils::{class_list, mount_style, OptionalProp};
+use thaw_components::OptionComp;
+use thaw_utils::{class_list, mount_style, OptionalMaybeSignal, OptionalProp};
 
 #[component]
 pub fn MenuItem(
     #[prop(into)] key: MaybeSignal<String>,
+    #[prop(optional, into)] icon: OptionalMaybeSignal<icondata_core::Icon>,
     #[prop(into)] label: MaybeSignal<String>,
     #[prop(optional, into)] class: OptionalProp<MaybeSignal<String>>,
 ) -> impl IntoView {
@@ -46,6 +48,15 @@ pub fn MenuItem(
                 on:click=on_click
                 style=move || css_vars.get()
             >
+                {
+                    move || {
+                        view! {
+                            <OptionComp value=icon.get() let:icon>
+                                <Icon icon=icon style="font-size: 18px;margin-right: 8px"/>
+                            </OptionComp>
+                        }
+                    }
+                }
                 {move || label.get()}
             </div>
         </div>

--- a/thaw/src/select/raw.rs
+++ b/thaw/src/select/raw.rs
@@ -50,6 +50,10 @@ where
         });
         on_cleanup(move || listener.remove());
     }
+    #[cfg(not(any(feature = "csr", feature = "hydrate")))]
+    {
+        let _ = hide_menu;
+    }
 
     let theme = use_theme(Theme::light);
     let css_vars = create_memo(move |_| {


### PR DESCRIPTION
This PR resolves issue #129 by adding optional callbacks to Input and InputNumber components. The `parser` callback converts user input to the desired signal format, while the `formatter` callback presents the signal value to the user. You can check it working in the Docs.