### PR TITLE
Improving server side rendering docs to include feature

### DIFF
--- a/demo_markdown/docs/_guide/server_sider_rendering.md
+++ b/demo_markdown/docs/_guide/server_sider_rendering.md
@@ -11,3 +11,15 @@ To enable the hydrate mode, the following configurations are required:
 ```toml
 thaw = { ..., features = ["hydrate"] }
 ```
+
+Remember to add thaw to your `Cargo.toml` fiile in the corresponding feature, e.g.
+
+```toml
+[features]
+...
+hydrate = [..., "thaw/hydrate"]
+ssr = [
+  ...
+  "thaw/ssr",
+]
+```

--- a/demo_markdown/docs/_guide/server_sider_rendering.md
+++ b/demo_markdown/docs/_guide/server_sider_rendering.md
@@ -12,7 +12,7 @@ To enable the hydrate mode, the following configurations are required:
 thaw = { ..., features = ["hydrate"] }
 ```
 
-Remember to add thaw to your `Cargo.toml` fiile in the corresponding feature, e.g.
+Remember to add thaw to your `Cargo.toml` file in the corresponding feature, e.g.
 
 ```toml
 [features]


### PR DESCRIPTION
I was trying thaw and stumble accross an error `cannot call wasm-bindgen imported functions on non-wasm targets` when trying to serve my basic leptos page. It turns out the feature need to be added to those lists on `Cargo.toml` for thaw to work. This might be obvious to more experienced devs in rust, but me being a newbie couldn't solved it by myself.