### PR TITLE
feat: add target to Link

### DIFF
--- a/thaw/src/link/docs/mod.md
+++ b/thaw/src/link/docs/mod.md
@@ -77,3 +77,4 @@ view! {
 | disabled | `MaybeSignal<bool>` | `false` | Whether the link is disabled. |
 | disabled_focusable | `MaybeSignal<bool>` | `false` | When set, allows the link to be focusable even when it has been disabled. |
 | children | `Children` |  |  |
+| target | `MaybeSignal<String>` |  | Specifies where to open the linked document. |

--- a/thaw/src/link/link.rs
+++ b/thaw/src/link/link.rs
@@ -16,6 +16,9 @@ pub fn Link(
     #[prop(optional, into)]
     disabled_focusable: MaybeSignal<bool>,
     children: Children,
+    /// Specifies where to open the linked document.
+    #[prop(optional, into)]
+    target: MaybeSignal<String>,
 ) -> impl IntoView {
     mount_style("link", include_str!("./link.css"));
 
@@ -46,6 +49,7 @@ pub fn Link(
                 href=href
                 tabindex=tabindex
                 aria-disabled=move || link_disabled.get().then_some("true")
+                target=target
             >
                 {children()}
             </a>


### PR DESCRIPTION
Adds target attribute to the `<a>` tag created by Link.

I wanted this for my app and noticed it didn't exist (among other attributes) so I thought I'd just add it :)