### PR TITLE
Declare MSRV of 1.79

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ members = [
 ]
 exclude = ["examples"]
 
+[workspace.package]
+rust-version = "1.79"
+
 [workspace.dependencies]
 thaw = { version = "0.4.0-beta3", path = "./thaw" }
 thaw_components = { version = "0.2.0-beta3", path = "./thaw_components" }

--- a/thaw/Cargo.toml
+++ b/thaw/Cargo.toml
@@ -10,6 +10,7 @@ homepage = "https://github.com/thaw-ui/thaw"
 repository = "https://github.com/thaw-ui/thaw"
 license = "MIT"
 exclude = ["src/**/*.md"]
+rust-version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/thaw_components/Cargo.toml
+++ b/thaw_components/Cargo.toml
@@ -8,6 +8,7 @@ authors = ["luoxiaozero"]
 description = "Shared Thaw internal components"
 repository = "https://github.com/thaw-ui/thaw"
 license = "MIT"
+rust-version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/thaw_macro/Cargo.toml
+++ b/thaw_macro/Cargo.toml
@@ -8,6 +8,7 @@ authors = ["luoxiaozero"]
 description = "Shared Thaw internal macro"
 repository = "https://github.com/thaw-ui/thaw"
 license = "MIT"
+rust-version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/thaw_utils/Cargo.toml
+++ b/thaw_utils/Cargo.toml
@@ -8,6 +8,7 @@ authors = ["luoxiaozero"]
 description = "Shared Thaw utility functions"
 repository = "https://github.com/thaw-ui/thaw"
 license = "MIT"
+rust-version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
This declares the MSRV globally at package level, even though the dependency seems to be only with thaw_components today, to make the setting easier to manage (like Leptos does).

Leptos 0.7.0-gamma2 exposes a MSRV of 1.76, but with 1.78 and earlier:

```
    Compiling thaw_components v0.2.0-beta3 (https://github.com/thaw-ui/thaw?rev=0c5cb880950ff2229ab2762bfa64a900b70a857d#0c5cb880)
 error[E0716]: temporary value dropped while borrowed
   --> /home/user/.cargo/git/checkouts/thaw-057be4168b51a04a/0c5cb88/thaw_components/src/teleport/mod.rs:15:14
    |
 11 |           let mount = if let Some(el) = mount.as_ref() {
    |               ----- borrow later stored here
 ...
 15 |               &document()
    |  ______________^
 16 | |                 .body()
 17 | |                 .expect("body element to exist")
 18 | |                 .unchecked_into()
    | |_________________________________^ creates a temporary value which is freed while still in use
 19 |           };
    |           - temporary value is freed at the end of this statement
    |
    = note: consider using a `let` binding to create a longer lived value
```
