### PR TITLE
feat: Make Model<T> use SignalSetter instead of WriteSignal

### DIFF
--- a/examples/ssr_axum/Cargo.toml
+++ b/examples/ssr_axum/Cargo.toml
@@ -18,7 +18,7 @@ leptos_router = { version = "0.6.14" }
 log = "0.4"
 simple_logger = "4"
 tokio = { version = "1.35.1", features = ["rt-multi-thread"], optional = true }
-tower = { version = "0.4.13", optional = true }
+tower = { version = "0.4.13", features = ["util"], optional = true }
 tower-http = { version = "0.5.1", features = ["fs"], optional = true }
 wasm-bindgen = "=0.2.93"
 thiserror = "1.0.56"


### PR DESCRIPTION
Proposal for #271, targets the 0.3  branch.

What we are trying to achieve: Make a more generic interface for `Model<T>`. This specifically addresses the issue of `From<(Signal, SignalSetter)>`.

How we did it: Switch the internals of `Model<T>` from `WriteSignal<T>` to `SignalSetter<T>`. This leads us to having to implement `SignalUpdate<T>` for `Model<T>` manually.

How we tested it: `cargo test` seems to take issue with the doctests at compile time, which I do not understand (yet). Other tests seem to work fine fine.