### PR TITLE
feat: add `readonly` and `size` props to `Input`

### DIFF
--- a/thaw/src/input/docs/mod.md
+++ b/thaw/src/input/docs/mod.md
@@ -114,6 +114,8 @@ view! {
 | input_type | `Signal<InputType>` | `InputType::Text` | An input can have different text-based types based on the type of value the user will enter. |
 | placeholder | `MaybeProp<String>` | `Default::default()` | Placeholder text for the input. |
 | disabled | `Signal<bool>` | `false` | Whether the input is disabled. |
+| readonly | `Signal<bool>` | `false` | Whether the input is readonly. |
+| size | `Signal<Option<i32>>` | `None` | The input size width. |
 | on_focus | `Option<BoxOneCallback<ev::FocusEvent>>` | `None` | Callback triggered when the input is focussed on. |
 | on_blur | `Option<BoxOneCallback<ev::FocusEvent>>` | `None` | Callback triggered when the input is blurred. |
 | parser | `OptionalProp<BoxOneCallback<String, Option<String>>>` | `None` | Modifies the user input before assigning it to the value. |

--- a/thaw/src/input/docs/mod.md
+++ b/thaw/src/input/docs/mod.md
@@ -115,7 +115,7 @@ view! {
 | placeholder | `MaybeProp<String>` | `Default::default()` | Placeholder text for the input. |
 | disabled | `Signal<bool>` | `false` | Whether the input is disabled. |
 | readonly | `Signal<bool>` | `false` | Whether the input is readonly. |
-| size | `Signal<Option<i32>>` | `None` | The input size width. |
+| input_size | `Signal<Option<i32>>` | `None` | The input size width. |
 | on_focus | `Option<BoxOneCallback<ev::FocusEvent>>` | `None` | Callback triggered when the input is focussed on. |
 | on_blur | `Option<BoxOneCallback<ev::FocusEvent>>` | `None` | Callback triggered when the input is blurred. |
 | parser | `OptionalProp<BoxOneCallback<String, Option<String>>>` | `None` | Modifies the user input before assigning it to the value. |

--- a/thaw/src/input/mod.rs
+++ b/thaw/src/input/mod.rs
@@ -56,7 +56,7 @@ pub fn Input(
     readonly: Signal<bool>,
     /// Input size width.
     #[prop(optional, into)]
-    size: Signal<Option<i32>>,
+    input_size: Signal<Option<i32>>,
     #[prop(optional)] input_prefix: Option<InputPrefix>,
     #[prop(optional)] input_suffix: Option<InputSuffix>,
     #[prop(optional)] comp_ref: ComponentRef<InputRef>,
@@ -193,7 +193,7 @@ pub fn Input(
                 class="thaw-input__input"
                 disabled=disabled
                 readonly=readonly
-                size=size
+                size=input_size
                 placeholder=move || placeholder.get()
                 node_ref=input_ref
             />

--- a/thaw/src/input/mod.rs
+++ b/thaw/src/input/mod.rs
@@ -51,6 +51,12 @@ pub fn Input(
     /// Whether the input is disabled.
     #[prop(optional, into)]
     disabled: Signal<bool>,
+    /// Whether the input is readonly.
+    #[prop(optional, into)]
+    readonly: Signal<bool>,
+    /// Input size width.
+    #[prop(optional, into)]
+    size: Signal<Option<i32>>,
     #[prop(optional)] input_prefix: Option<InputPrefix>,
     #[prop(optional)] input_suffix: Option<InputSuffix>,
     #[prop(optional)] comp_ref: ComponentRef<InputRef>,
@@ -185,7 +191,9 @@ pub fn Input(
                 on:focus=on_internal_focus
                 on:blur=on_internal_blur
                 class="thaw-input__input"
-                disabled=move || disabled.get()
+                disabled=disabled
+                readonly=readonly
+                size=size
                 placeholder=move || placeholder.get()
                 node_ref=input_ref
             />
@@ -281,10 +289,7 @@ impl InputRule {
         })
     }
 
-    pub fn required_with_message(
-        required: Signal<bool>,
-        message: Signal<String>,
-    ) -> Self {
+    pub fn required_with_message(required: Signal<bool>, message: Signal<String>) -> Self {
         Self::validator(move |value, _| {
             if required.get_untracked() && value.is_empty() {
                 Err(FieldValidationState::Error(message.get_untracked()))


### PR DESCRIPTION
Adds readonly and size props to the input component. The size prop is the input [size](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/size) attribute.