### PR TITLE
feat: add `scrollable` prop to `DrawerBody`

### DIFF
--- a/thaw/src/drawer/docs/mod.md
+++ b/thaw/src/drawer/docs/mod.md
@@ -216,7 +216,8 @@ view! {
 
 ### DrawerBody Props
 
-| Name     | Type                | Default              | Description |
-| -------- | ------------------- | -------------------- | ----------- |
-| class    | `MaybeProp<String>` | `Default::default()` |             |
-| children | `Children`          |                      |             |
+| Name       | Type                | Default              | Description                              |
+| ---------- | ------------------- | -------------------- | ---------------------------------------- |
+| class      | `MaybeProp<String>` | `Default::default()` |                                          |
+| scrollable | `Signal<bool>`      | `true`               | Allows the drawer body to be scrollable. |
+| children   | `Children`          |                      |                                          |

--- a/thaw/src/drawer/docs/mod.md
+++ b/thaw/src/drawer/docs/mod.md
@@ -219,5 +219,5 @@ view! {
 | Name       | Type                | Default              | Description                              |
 | ---------- | ------------------- | -------------------- | ---------------------------------------- |
 | class      | `MaybeProp<String>` | `Default::default()` |                                          |
-| scrollable | `Signal<bool>`      | `true`               | Allows the drawer body to be scrollable. |
+| scrollable | `bool`              | `true`               | Allows the drawer body to be scrollable. |
 | children   | `Children`          |                      |                                          |

--- a/thaw/src/drawer/drawer_body.rs
+++ b/thaw/src/drawer/drawer_body.rs
@@ -1,20 +1,24 @@
 use leptos::prelude::*;
 use thaw_utils::class_list;
 
+use crate::Scrollbar;
+
 #[component]
 pub fn DrawerBody(
     #[prop(optional, into)] class: MaybeProp<String>,
-    #[prop(into, default = true)] scrollable: Signal<bool>,
+    #[prop(default = true)] scrollable: bool,
     children: Children,
 ) -> impl IntoView {
-    move || match scrollable.get() {
+    match scrollable {
         true => view! {
             <Scrollbar>
                 <div class=class_list!["thaw-drawer-body", class]>{children()}</div>
             </Scrollbar>
-        },
+        }
+        .into_any(),
         false => view! {
             <div class=class_list!["thaw-drawer-body", class]>{children()}</div>
-        },
+        }
+        .into_any(),
     }
 }

--- a/thaw/src/drawer/drawer_body.rs
+++ b/thaw/src/drawer/drawer_body.rs
@@ -1,15 +1,20 @@
-use crate::Scrollbar;
 use leptos::prelude::*;
 use thaw_utils::class_list;
 
 #[component]
 pub fn DrawerBody(
     #[prop(optional, into)] class: MaybeProp<String>,
+    #[prop(into, default = true)] scrollable: Signal<bool>,
     children: Children,
 ) -> impl IntoView {
-    view! {
-        <Scrollbar>
+    move || match scrollable.get() {
+        true => view! {
+            <Scrollbar>
+                <div class=class_list!["thaw-drawer-body", class]>{children()}</div>
+            </Scrollbar>
+        },
+        false => view! {
             <div class=class_list!["thaw-drawer-body", class]>{children()}</div>
-        </Scrollbar>
+        },
     }
 }


### PR DESCRIPTION
I have a case where I'd line an inner element within the DrawerBody to be scrollable, and the drawerbody itself does not need to be scrollable.

To solve this, I've added an optional `scrollable` prop to the `DrawerBody`.