### PR TITLE
feat: add `Send` + `Sync` bounds to `RuleValidator`

### DIFF
--- a/thaw/src/field/rule.rs
+++ b/thaw/src/field/rule.rs
@@ -5,7 +5,8 @@ use send_wrapper::SendWrapper;
 use std::ops::Deref;
 use thaw_utils::{Model, OptionModel, OptionModelWithValue, VecModel, VecModelWithValue};
 
-type RuleValidator<T> = Box<dyn Fn(&T, Signal<Option<String>>) -> Result<(), FieldValidationState>>;
+type RuleValidator<T> =
+    Box<dyn Fn(&T, Signal<Option<String>>) -> Result<(), FieldValidationState> + Send + Sync>;
 
 pub struct Rule<T, Trigger> {
     validator: RuleValidator<T>,


### PR DESCRIPTION
The `RuleValidator` type has issues with leptos 0.7 due to the lack of Send + Sync trait bounds.