### PR TITLE
feat: generify menu

### DIFF
--- a/demo/src/components/site_header.rs
+++ b/demo/src/components/site_header.rs
@@ -5,6 +5,14 @@ use leptos_router::hooks::use_navigate;
 // use leptos_use::{storage::use_local_storage, utils::FromToStringCodec};
 use thaw::*;
 
+#[derive(Clone)]
+enum HeaderAction {
+    ChangeTheme,
+    Github,
+    Discord,
+    Navigate(&'static str),
+}
+
 #[component]
 pub fn SiteHeader() -> impl IntoView {
     let navigate = use_navigate();
@@ -172,19 +180,18 @@ pub fn SiteHeader() -> impl IntoView {
                 </AutoComplete>
                 <Menu
                     position=MenuPosition::BottomEnd
-                    on_select=move |value: String| match value.as_str() {
-                        "Dark" => change_theme(MouseEvent::new("click").unwrap()),
-                        "Light" => change_theme(MouseEvent::new("click").unwrap()),
-                        "github" => {
+                    on_select=move |value: HeaderAction| match value {
+                        HeaderAction::ChangeTheme => change_theme(MouseEvent::new("click").unwrap()),
+                        HeaderAction::Github => {
                             _ = window().open_with_url("http://github.com/thaw-ui/thaw");
                         }
-                        "discord" => {
+                        HeaderAction::Discord => {
                             _ = window()
                                 .open_with_url(
                                     "https://discord.gg/VwtS7b8c",
                                 );
                         }
-                        _ => navigate_signal.get()(&value, Default::default()),
+                        HeaderAction::Navigate(value) => navigate_signal.get()(&value, Default::default()),
                     }
                 >
                     <MenuTrigger slot>
@@ -195,13 +202,13 @@ pub fn SiteHeader() -> impl IntoView {
                             attr:style="font-size: 22px; padding: 0px 6px;"
                         />
                     </MenuTrigger>
-                    <MenuItem value=theme_name>{theme_name}</MenuItem>
-                    <MenuItem icon=icondata::AiGithubOutlined value="github">
+                    <MenuItem<HeaderAction> value=HeaderAction::ChangeTheme>{theme_name}</MenuItem<HeaderAction>>
+                    <MenuItem<HeaderAction> value=HeaderAction::Github icon=icondata::AiGithubOutlined>
                         "Github"
-                    </MenuItem>
-                    <MenuItem icon=icondata::BiDiscordAlt value="discord">
+                    </MenuItem<HeaderAction>>
+                    <MenuItem<HeaderAction>  value=HeaderAction::Discord icon=icondata::BiDiscordAlt>
                         "Discord"
-                    </MenuItem>
+                    </MenuItem<HeaderAction>>
                     {
                         use crate::pages::{gen_nav_data, NavGroupOption, NavItemOption};
                         gen_nav_data()
@@ -216,7 +223,7 @@ pub fn SiteHeader() -> impl IntoView {
                                         .into_iter()
                                         .map(|item| {
                                             let NavItemOption { label, value, .. } = item;
-                                            view! { <MenuItem value=value>{label}</MenuItem> }
+                                            view! { <MenuItem<HeaderAction> value=HeaderAction::Navigate(value)>{label}</MenuItem<HeaderAction>> }
                                         })
                                         .collect_view()}
                                 }

--- a/thaw/src/menu/docs/mod.md
+++ b/thaw/src/menu/docs/mod.md
@@ -3,12 +3,13 @@
 ```rust demo
 let toaster = ToasterInjection::expect_context();
 
-let on_select = move |key: String| {
+let on_select = move |key: &str| {
   leptos::logging::warn!("{}", key);
+  let key = key.to_owned();
   toaster.dispatch_toast(move || view! {
         <Toast>
             <ToastBody>
-                "key"
+                {key}
             </ToastBody>
         </Toast>
   }, Default::default());
@@ -41,7 +42,7 @@ view! {
 ```rust demo
 use leptos_meta::Style;
 
-let on_select = move |value| leptos::logging::warn!("{}", value);
+let on_select = move |value: &str| leptos::logging::warn!("{}", value);
 
 view! {
     <Style>
@@ -153,25 +154,25 @@ view! {
 | Name         | Type                        | Default                  | Description                                  |
 | ------------ | --------------------------- | ------------------------ | -------------------------------------------- |
 | class        | `MaybeProp<String>,`        | `Default::default()`     |                                              |
-| on_select    | `BoxOneCallback<String>`    |                          | Called when item is selected.                |
+| on_select    | `BoxOneCallback<V>`         |                          | Called when item is selected.                |
 | trigger_type | `MenuTriggerType`           | `MenuTriggerType::Click` | Action that displays the menu.               |
 | position     | `MenuPosition`              | `MenuPosition::Bottom`   | Menu position.                               |
 | appearance   | `MaybeProp<MenuAppearance>` | `Default::default()`     |                                              |
 | menu_trigger | slot `MenuTrigger`          |                          | The element or component that triggers menu. |
 | children     | `Children`                  |                          |                                              |
 
-### MenuTriger Props
+### MenuTrigger Props
 
 | Name     | Type                                        | Default | Description |
 | -------- | ------------------------------------------- | ------- | ----------- |
 | children | `T: AddAnyAttr + IntoView + Send + 'static` |         |             |
 
-### MenuItem Props
+### MenuItem&lt;V&gt; Props
 
 | Name     | Type                             | Default              | Description                        |
 | -------- | -------------------------------- | -------------------- | ---------------------------------- |
 | class    | `MaybeProp<String>`              | `Default::default()` |                                    |
-| value    | `Signal<String>`                 | `Default::default()` | The value of the menu item.        |
+| value    | `V`                              |                      | The value of the menu item.        |
 | icon     | `MaybeProp<icondata_core::Icon>` | `None`               | The icon of the menu item.         |
 | disabled | `Signal<bool>`                   | `false`              | Whether the menu item is disabled. |
 | children | `Children`                       |                      |                                    |

--- a/thaw/src/menu/menu_item.rs
+++ b/thaw/src/menu/menu_item.rs
@@ -4,14 +4,13 @@ use thaw_components::{Fallback, If, OptionComp, Then};
 use thaw_utils::{class_list, mount_style};
 
 #[component]
-pub fn MenuItem(
+pub fn MenuItem<V: Clone + Send + Sync + 'static>(
     #[prop(optional, into)] class: MaybeProp<String>,
     /// The icon of the menu item.
     #[prop(optional, into)]
     icon: MaybeProp<icondata_core::Icon>,
     /// The value of the menu item.
-    #[prop(into)]
-    value: Signal<String>,
+    value: V,
     /// Whether the menu item is disabled.
     #[prop(optional, into)]
     disabled: Signal<bool>,
@@ -33,7 +32,7 @@ pub fn MenuItem(
             return;
         }
 
-        on_select(value.get_untracked());
+        on_select(value.clone());
     };
 
     view! {

--- a/thaw/src/menu/mod.rs
+++ b/thaw/src/menu/mod.rs
@@ -21,7 +21,7 @@ pub struct MenuTrigger<T> {
 }
 
 #[component]
-pub fn Menu<T>(
+pub fn Menu<T, V: 'static>(
     #[prop(optional, into)] class: MaybeProp<String>,
     /// The element or component that triggers menu.
     menu_trigger: MenuTrigger<T>,
@@ -33,7 +33,7 @@ pub fn Menu<T>(
     position: MenuPosition,
     /// Called when item is selected.
     #[prop(into)]
-    on_select: BoxOneCallback<String>,
+    on_select: BoxOneCallback<V>,
     #[prop(optional, into)] appearance: MaybeProp<MenuAppearance>,
     children: Children,
 ) -> impl IntoView
@@ -146,12 +146,12 @@ where
 }
 
 #[derive(Clone)]
-pub(crate) struct MenuInjection {
+pub(crate) struct MenuInjection<V> {
     has_icon: RwSignal<bool>,
-    on_select: ArcOneCallback<String>,
+    on_select: ArcOneCallback<V>,
 }
 
-impl MenuInjection {
+impl<V: Clone + 'static> MenuInjection<V> {
     pub fn expect_context() -> Self {
         expect_context()
     }


### PR DESCRIPTION
Most of the time I found that I would want to use an enum for the MenuItem's, so this PR generifies Menu/MenuItem so that any type which satisfies Clone can be used as value.

Of course with the generics we hit https://github.com/leptos-rs/leptos/issues/3200#issuecomment-2483121002 so the type needs to be specified when creating the MenuItem's.

I wonder if `value` even needs to be a `Signal` or if it could be a simple value?

