### PR TITLE
allow typing space

### DIFF
--- a/thaw/src/combobox/common/listbox.rs
+++ b/thaw/src/combobox/common/listbox.rs
@@ -78,8 +78,8 @@ pub fn listbox_keyboard_event(
             }
         }
         DropdownAction::CloseSelect | DropdownAction::Select => {
-            e.prevent_default();
             if let Some(option) = active_option {
+                e.prevent_default();
                 select_option(option);
             }
         }


### PR DESCRIPTION
when using auto complete as a search box it would be nice to be able to enter a space. I think this might be a compromise that allows both space to be used to open and  select items as well as to be used as a space when once the listbox is open.