### PR TITLE
validation message alignment

### DIFF
--- a/thaw/src/field/field.css
+++ b/thaw/src/field/field.css
@@ -31,6 +31,8 @@
     font-size: var(--fontSizeBase200);
     font-weight: var(--fontWeightRegular);
     line-height: var(--lineHeightBase200);
+    display: flex;
+    align-items: center;
 }
 
 .thaw-field--error > .thaw-field__validation-message {


### PR DESCRIPTION
Hey, 

Tiny fix. The validation icon and message were misaligned:

<img width="208" height="64" alt="image" src="https://github.com/user-attachments/assets/001d3c4d-c2ed-4085-8595-28f15a8f0748" />

With this fix:

<img width="255" height="56" alt="image" src="https://github.com/user-attachments/assets/bc3a9257-e1a7-4807-b3ea-3d65eed7fdcb" />

I've check fluent and it's aligned there but they are not using `display: flex`. I wasn't able to figure out how they align it. If there is a better way I can change it. 