### PR TITLE
style(skeleton-item): set background-position-x to 115% to represent the infinite loading behavior as in v0.3

### DIFF
--- a/thaw/src/skeleton/skeleton-item.css
+++ b/thaw/src/skeleton/skeleton-item.css
@@ -22,7 +22,7 @@
 
 @keyframes thaw-skeleton-item {
     0% {
-        background-position-x: 300%;
+        background-position-x: 115%;
     }
 
     100% {


### PR DESCRIPTION
Back in version 0.3 the background-position was set to from 100% 50% and to 0% 50% which created that infinite loop look.
In the current version, that behavior is gone since setting the background-position-x from 300% makes the animation loop look like it's restarting instead of infinite looping.

https://github.com/user-attachments/assets/eecade64-c99f-43f9-ab09-a3d9491d0cb3

<img width="1904" height="723" alt="Screenshot_1" src="https://github.com/user-attachments/assets/5bc236c4-d369-451e-af6a-4ff7b40fb944" />
<img width="1152" height="882" alt="Screenshot_2" src="https://github.com/user-attachments/assets/045e826d-862d-428d-8061-c567d554be29" />
