### PR TITLE
feat: Adds blur button function

### DIFF
--- a/thaw/src/button/button/types.rs
+++ b/thaw/src/button/button/types.rs
@@ -127,4 +127,11 @@ impl ButtonRef {
             _ = button_el.focus();
         }
     }
+
+    /// Blur the button element
+    pub fn blur(&self) {
+        if let Some(button_el) = self.button_ref.get_untracked() {
+            _ = button_el.blur()
+        }
+    }
 }

--- a/thaw/src/button/docs/mod.md
+++ b/thaw/src/button/docs/mod.md
@@ -253,3 +253,4 @@ view! {
 | ----- | ----------- | ------------------------- |
 | click | `Fn(&self)` | Click the button element. |
 | focus | `Fn(&self)` | Focus the button element. |
+| blur  | `Fn(&self)` | Blurs the button element. |


### PR DESCRIPTION
We had the usecase of needing to unfocus the button element. Since `.blur()` was not exposed, we decided to add it.