### PR TITLE
--cfg=web_sys_unstable_apis changes position APIs in web_sys to use f64 instead of i32

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ thaw_utils = { version = "0.2.0-beta", path = "./thaw_utils" }
 leptos = { version = "0.8.5" }
 leptos_meta = { version = "0.8.5" }
 leptos_router = { version = "0.8.5" }
-reactive_stores = { version = "0.2.5" }
+reactive_stores = { version = "0.4.3" }
 
 # web
 wasm-bindgen = { version = "0.2.100" }

--- a/thaw/Cargo.toml
+++ b/thaw/Cargo.toml
@@ -12,6 +12,9 @@ license = "MIT"
 exclude = ["src/**/*.md"]
 rust-version.workspace = true
 
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(web_sys_unstable_apis)'] }
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/thaw/Cargo.toml
+++ b/thaw/Cargo.toml
@@ -35,7 +35,7 @@ web-sys = { version = "0.3.72", features = [
 ] }
 wasm-bindgen = { workspace = true }
 icondata_core = "0.1.0"
-icondata_ai = "0.0.10"
+icondata_ai = "0.1"
 uuid = { version = "1.10.0", features = ["v4", "js"] }
 cfg-if = "1.0.0"
 chrono = "0.4.38"

--- a/thaw/src/back_top/mod.rs
+++ b/thaw/src/back_top/mod.rs
@@ -57,7 +57,7 @@ pub fn BackTop(
             }
 
             let handle = add_event_listener(scroll_el.clone(), ev::scroll, move |_| {
-                scroll_top.set(scroll_el.scroll_top());
+                scroll_top.set(thaw_utils::maybe_unstable!(scroll_el.scroll_top()));
             });
             scroll_handle.set_value(Some(handle));
         });

--- a/thaw/src/lib.rs
+++ b/thaw/src/lib.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 mod _aria;
 mod _binder;
 mod _motion;

--- a/thaw/src/scrollbar/mod.rs
+++ b/thaw/src/scrollbar/mod.rs
@@ -109,8 +109,8 @@ pub fn Scrollbar(
 
     let sync_scroll_state = move || {
         if let Some(el) = container_ref.get_untracked() {
-            container_scroll_top.set(el.scroll_top());
-            container_scroll_left.set(el.scroll_left());
+            container_scroll_top.set(thaw_utils::maybe_unstable!(el.scroll_top()));
+            container_scroll_left.set(thaw_utils::maybe_unstable!(el.scroll_left()));
         }
     };
     let sync_position_state = move || {
@@ -173,7 +173,7 @@ pub fn Scrollbar(
             let x_track_width = x_track_width.get();
             let x_thumb_width = x_thumb_width.get() as i32;
 
-            let x_diff = e.client_x() - memo_mouse_x.get_value();
+            let x_diff = thaw_utils::maybe_unstable!(e.client_x()) - memo_mouse_x.get_value();
             let to_scroll_left_upper_bound = content_width - container_width;
             let scroll_left =
                 (x_diff * to_scroll_left_upper_bound) / (x_track_width - x_thumb_width);
@@ -183,7 +183,7 @@ pub fn Scrollbar(
             to_scroll_left = to_scroll_left.max(0);
 
             if let Some(el) = container_ref.get_untracked() {
-                el.set_scroll_left(to_scroll_left);
+                el.set_scroll_left(thaw_utils::maybe_unstable!(INV to_scroll_left));
             }
         });
         x_trumb_mousemove_handle.set_value(Some(handle));
@@ -209,7 +209,7 @@ pub fn Scrollbar(
         });
         x_trumb_mouseup_handle.set_value(Some(handle));
         memo_x_left.set_value(container_scroll_left.get());
-        memo_mouse_x.set_value(e.client_x());
+        memo_mouse_x.set_value(thaw_utils::maybe_unstable!(e.client_x()));
         thumb_status.set_value(Some(ThumbStatus::Enter));
     };
 
@@ -226,7 +226,7 @@ pub fn Scrollbar(
             let y_track_height = y_track_height.get();
             let y_thumb_height = y_thumb_height.get() as i32;
 
-            let y_diff = e.client_y() - memo_mouse_y.get_value();
+            let y_diff = thaw_utils::maybe_unstable!(e.client_y()) - memo_mouse_y.get_value();
             let to_scroll_top_upper_bound = content_height - container_height;
             let scroll_top =
                 (y_diff * to_scroll_top_upper_bound) / (y_track_height - y_thumb_height);
@@ -236,7 +236,7 @@ pub fn Scrollbar(
             to_scroll_top = to_scroll_top.max(0);
 
             if let Some(el) = container_ref.get_untracked() {
-                el.set_scroll_top(to_scroll_top);
+                el.set_scroll_top(thaw_utils::maybe_unstable!(INV to_scroll_top));
             }
         });
         y_trumb_mousemove_handle.set_value(Some(handle));
@@ -262,7 +262,7 @@ pub fn Scrollbar(
         });
         y_trumb_mouseup_handle.set_value(Some(handle));
         memo_y_top.set_value(container_scroll_top.get());
-        memo_mouse_y.set_value(e.client_y());
+        memo_mouse_y.set_value(thaw_utils::maybe_unstable!(e.client_y()));
         thumb_status.set_value(Some(ThumbStatus::Enter));
     };
 

--- a/thaw_utils/Cargo.toml
+++ b/thaw_utils/Cargo.toml
@@ -10,6 +10,9 @@ repository = "https://github.com/thaw-ui/thaw"
 license = "MIT"
 rust-version.workspace = true
 
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(web_sys_unstable_apis)'] }
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/thaw_utils/src/hooks/use_click_position.rs
+++ b/thaw_utils/src/hooks/use_click_position.rs
@@ -12,8 +12,10 @@ pub fn use_click_position() -> ReadSignal<Option<(i32, i32)>> {
         use web_sys::MouseEvent;
 
         fn click_handler(event: MouseEvent) -> Option<(i32, i32)> {
-            if event.client_x() > 0 || event.client_y() > 0 {
-                return Some((event.client_x(), event.client_y()));
+            let client_x = crate::maybe_unstable!(event.client_x());
+            let client_y = crate::maybe_unstable!(event.client_y());
+            if client_x > 0 || client_y > 0 {
+                return Some((client_x, client_y));
             }
             let Some(target) = event.target() else {
                 return None;

--- a/thaw_utils/src/lib.rs
+++ b/thaw_utils/src/lib.rs
@@ -19,3 +19,27 @@ pub use optional_prop::OptionalProp;
 pub use signals::*;
 pub use throttle::throttle;
 pub use time::now_date;
+
+#[macro_export]
+macro_rules! maybe_unstable {
+    (INV $e:expr) => {{
+        #[cfg(web_sys_unstable_apis)]
+        {
+            $e as f64
+        }
+        #[cfg(not(web_sys_unstable_apis))]
+        {
+            $e
+        }
+    }};
+    ($e:expr) => {{
+        #[cfg(web_sys_unstable_apis)]
+        {
+            $e.round() as i32
+        }
+        #[cfg(not(web_sys_unstable_apis))]
+        {
+            $e
+        }
+    }};
+}


### PR DESCRIPTION
if `web_sys_unstable_apis` is active, several methods in `web_sys` use f64 instead of i32 (e.g. scroll offsets, mouse positions), which breaks several methods in thaw. To fix this, I added an exported macro to thaw_utils to be as uninvasive as possible, that converts f64 to i32 or vice versa iff `web_sys_unstable_apis` is active and wrap that around the offending function calls.

To verify that the previous version breaks and this one works, run `RUSTFLAGS="--cfg=web_sys_unstable_apis" trunk build` in `demo`.